### PR TITLE
Add support for RHEL 8 and 9

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -107,8 +107,7 @@ check_secure_boot() {
 			echo "Warning: Secure Boot is enabled."
 			echo "On RHEL/CentOS 8, the WireGuard kernel module is provided by ELRepo and is not signed by Red Hat."
 			echo "The module will likely fail to load unless you disable Secure Boot or enroll the ELRepo key."
-			echo "It is strongly recommended to disable Secure Boot before proceeding."
-			read -n1 -r -p "Press any key to continue..."
+			exiterr "Secure Boot is enabled. Disable Secure Boot or enroll the ELRepo key before proceeding."
 		fi
 	fi
 }
@@ -1063,10 +1062,6 @@ EOF
 
 start_wg_service() {
 	# Enable and start the wg-quick service
-	if ! modprobe -nq wireguard; then
-		echo "Warning: WireGuard kernel module not found. Skipping service start."
-		return
-	fi
 	(
 		set -x
 		systemctl enable --now wg-quick@wg0.service >/dev/null 2>&1
@@ -1087,9 +1082,6 @@ finish_setup() {
 		echo "Reboot the system to load the most recent kernel."
 	else
 		echo "Finished!"
-		if [[ "$os" == "centos" || "$os" == "rhel" || "$os" == "fedora" ]]; then
-			echo "It is recommended to reboot your system once setup is complete."
-		fi
 	fi
 	echo
 	echo "The client configuration is available in: $export_dir$client.conf"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -1016,11 +1016,7 @@ update_sysctl() {
 	fi
 	# Optimize sysctl settings such as TCP buffer sizes
 	base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
-	if [ "$os" = "rhel" ]; then
-		conf_url="$base_url/sysctl-wg-centos"
-	else
-		conf_url="$base_url/sysctl-wg-$os"
-	fi
+	conf_url="$base_url/sysctl-wg-$os"
 	[ "$auto" != 0 ] && conf_url="${conf_url}-auto"
 	wget -t 3 -T 30 -q -O "$conf_opt" "$conf_url" 2>/dev/null \
 		|| curl -m 30 -fsL "$conf_url" -o "$conf_opt" 2>/dev/null \


### PR DESCRIPTION
  Changes Summary:
   - RHEL 8 & 9 Detection: The script now correctly identifies RHEL and verifies that the version is at least 8.
   - Automated Installation:
       - RHEL 9: Installs epel-release and wireguard-tools.
       - RHEL 8: Installs epel-release, elrepo-release, and the kmod-wireguard kernel module.
   - Secure Boot Detection: Added a proactive check for Secure Boot on RHEL/CentOS 8. It warns users that the ELRepo
     module won't load unless Secure Boot is disabled or the key is enrolled.
   - Robust Service Start: The script now checks if the WireGuard module is loaded before attempting to start the
     systemd service, avoiding "failed" states before the required reboot.
   - Reboot Guidance: Explicitly recommends a reboot for RHEL-based systems to ensure the kernel module is active.